### PR TITLE
[DRAFT] Add open-source library XGBOOST to vcpkg

### DIFF
--- a/ports/xgboost/portfile.cmake
+++ b/ports/xgboost/portfile.cmake
@@ -1,0 +1,38 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO dmlc/xgboost
+    REF v1.7.6
+    SHA512 4465f383df70ee415faaeb745459bfc413f71bff0d02e59e67173975188bed911044dbea1a456550496f8c5a7c0b50002275b6be72c87386a6118485e1e41829
+    HEAD_REF master
+)
+
+# Set the expected path of the dmlc-core directory inside the xgboost source directory
+vcpkg_from_github(
+    OUT_SOURCE_PATH DMLC_CORE_SRC
+    REPO dmlc/dmlc-core
+    REF 81db539486ce6525b31b971545edffee2754aced
+    SHA512 9b288fd1ceeef0015e80b0296b0d4015238d4cc1b7c36ba840d3eabce87508e62ed5b4fe61504f569dadcc414882903211fadf54aa0e162a896b03d7ca05e975
+    HEAD_REF master
+)
+
+# Custom CMake script to move dmlc-core to the correct location
+file(REMOVE_RECURSE "${SOURCE_PATH}/dmlc-core")
+file(RENAME "${DMLC_CORE_SRC}" "${SOURCE_PATH}/dmlc-core")
+
+# Configure and build dmlc-core first
+vcpkg_configure_cmake(
+    SOURCE_PATH "${SOURCE_PATH}/dmlc-core"
+    PREFER_NINJA
+    OPTIONS
+         -DBUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/xgboost" RENAME copyright)

--- a/ports/xgboost/vcpkg.json
+++ b/ports/xgboost/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "xgboost",
+  "version": "1.7.6",
+  "description": [
+    "XGBoost is an optimized distributed gradient boosting library designed to be highly efficient, flexible and portable. It implements machine learning algorithms under the Gradient Boosting framework.",
+    "XGBoost provides a parallel tree boosting (also known as GBDT, GBM) that solve many data science problems in a fast and accurate way.",
+    "The same code runs on major distributed environment (Kubernetes, Hadoop, SGE, Dask, Spark, PySpark) and can solve problems beyond billions of examples."
+  ],
+  "homepage": "https://github.com/dmlc/xgboost",
+  "license": "Apache-2.0",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/versions/baseline.json
+++ b/versions/baseline.json
@@ -9480,6 +9480,10 @@
       "baseline": "0.3.0",
       "port-version": 3
     },
+    "xgboost": {
+      "baseline": "1.7.6",
+      "port-version": 0
+    },
     "xlnt": {
       "baseline": "1.5.0",
       "port-version": 4

--- a/versions/x-/xgboost.json
+++ b/versions/x-/xgboost.json
@@ -1,0 +1,9 @@
+{
+  "versions": [
+    {
+      "git-tree": "7b957cc8d34940281801a65a6d04a0d70c8da77f",
+      "version": "1.7.6",
+      "port-version": 0
+    }
+  ]
+}


### PR DESCRIPTION
DRAFT
<!-- If this PR adds a new port, please uncomment and fill out this checklist:

- [ ] Changes comply with the [maintainer guide](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/contributing/maintainer-guide.md).
- [ ] The name of the port matches an existing name for this component on https://repology.org/ if possible, and/or is strongly associated with that component on search engines.
- [ ] Optional dependencies are resolved in exactly one way. For example, if the component is built with CMake, all `find_package` calls are REQUIRED, are satisfied by `vcpkg.json`'s declared dependencies, or disabled with [CMAKE_DISABLE_FIND_PACKAGE_Xxx](https://cmake.org/cmake/help/latest/variable/CMAKE_DISABLE_FIND_PACKAGE_PackageName.html).
- [ ] The versioning scheme in `vcpkg.json` matches what upstream says.
- [ ] The license declaration in `vcpkg.json` matches what upstream says.
- [ ] The installed as the "copyright" file matches what upstream says.
- [ ] The source code of the component installed comes from an authoritative source.
- [ ] The generated "usage text" is accurate. See [adding-usage](https://github.com/microsoft/vcpkg-docs/blob/main/vcpkg/examples/adding-usage.md) for context.
- [ ] The version database is fixed by rerunning `./vcpkg x-add-version --all` and committing the result.
- [ ] Only one version is in the new port's versions file.
- [ ] Only one version is added to each modified port's versions file.

END OF NEW PORT CHECKLIST (delete this line) -->
